### PR TITLE
Use Azure Extensions instead of cloud-init for Applications.

### DIFF
--- a/cassandra.tpl
+++ b/cassandra.tpl
@@ -187,3 +187,5 @@ fi
 
 sudo systemctl enable cassandra
 sudo systemctl start cassandra
+
+exit 0

--- a/opennms.tpl
+++ b/opennms.tpl
@@ -306,3 +306,5 @@ until printf "" 2>>/dev/null >>/dev/tcp/$ip_address/8980; do printf '.'; sleep 1
 # Import Test Requisition
 
 $opennms_home/bin/provision.pl requisition import AWS
+
+exit 0

--- a/vars.tf
+++ b/vars.tf
@@ -9,19 +9,19 @@ variable "location" {
 variable "resource_group_create" {
   description = "Set to true to create the resource group and the vnet"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "resource_group_name" {
   description = "Name of the resource group"
   type        = string
-  default     = "sales-testing"
+  default     = "cassandra-rg"
 }
 
 variable "vnet_name" {
   description = "Name of the Virtual Network within the chosen resource group"
   type        = string
-  default     = "sales-testing-vnet"
+  default     = "cassandra-vnet"
 }
 
 variable "username" {
@@ -37,12 +37,6 @@ variable "public_ssh_key" {
 }
 
 # Must be consistent with the chosen Location/Region
-# Use CI images for cloud-init support:
-# - OpenLogic:CentOS:7-CI:latest (slow execution of cloud-init script)
-# - RedHat:RHEL:7-RAW-CI:latest
-# Unlike when using Ubuntu, there is no cloud-init-output.log; instead:
-# sudo grep cloud-init /var/log/messages
-# Script available at /var/lib/cloud/instance/scripts/part-001
 variable "os_image" {
   description = "OS Image to use for OpenNMS and Cassandra"
   type = object({
@@ -54,7 +48,7 @@ variable "os_image" {
   default = {
     publisher = "OpenLogic"
     offer     = "CentOS"
-    sku       = "7-CI"
+    sku       = "8.0"
     version   = "latest"
   }
 }


### PR DESCRIPTION
When using cloud-init, besides being constrained to use certain
images, the execution was very slow.

To improve performance, I decided to use Azure Extensions to
execute the one-time set of commands to initialize Cassandra
and OpenNMS.